### PR TITLE
Fix: No package matching 'kong_dependencies' is available

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Install dependencies
   apt: pkg={{ item }} state=installed
-  with_items: kong_dependencies
+  with_items: "{{ kong_dependencies }}"
 
 - name: Install deb
   apt: deb={{ kong_working_dir }}/kong.deb


### PR DESCRIPTION
TASK [ansible-role-kong : Install dependencies] ********************************
failed: [kong] (item=[u'kong_dependencies']) => {"failed": true, "item": ["kong_dependencies"], "msg": "No package matching 'kong_dependencies' is available"}
	to retry, use: --limit @/home/vms/Vagrant/kong/playbooks/kong.retry

PLAY RECAP *********************************************************************
kong                       : ok=3    changed=1    unreachable=0    failed=1   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.